### PR TITLE
Fix render issue on multiple clients

### DIFF
--- a/email.html
+++ b/email.html
@@ -41,6 +41,7 @@ Email on Acid - http://www.emailonacid.com/blog/details/C18/doctype_-_the_black_
         /* Reset Styles */
         body { margin: 0; padding: 0; }
         img { height: auto; line-height: 100%; outline: none; text-decoration: none; }
+		a img { border:none; } /* Remove borders from emails in links. To remove in Lotus 6/7, add border="0" on the img tag aswell */
         #backgroundTable { margin: 0; padding: 0; width: 100% !important; }
 
     /** End Mail Chimp Reset **/ 

--- a/email_lite.html
+++ b/email_lite.html
@@ -15,6 +15,7 @@
         /* Reset Styles */
         body { margin: 0; padding: 0; }
         img { height: auto; line-height: 100%; outline: none; text-decoration: none; }
+		a img { border:none; }
         #backgroundTable { margin: 0; padding: 0; width: 100% !important; }
     
        p {


### PR DESCRIPTION
Fix render issue on iPad, iPhone, Thunderbird 2 and 3, and Lotus Notes 8 (depending on version of IE installed).

The height: 100% !important; on the #backgroundTable was causing problems in some browsers. Removing it seemed to fix it.
This is testet in:
Android 2.2
Apple Mail 4
Gmail (Explorer)
Gmail (Firefox)
Hotmail (Explorer)
Hotmail (Firefox)
iPad
iPhone
Lotus Notes 6.5, 7, 8 and 8.5
me.com (Firefox)
Outlook 2000, XP, 2003, 2007, 2010, 2011
Symbian S60
Thunderbird 2, 3
Windows Mobile 6.5

If needed I can provide screenshots at a later time.
