### PR TITLE
Removing spacing from around tables in outlook 2007 and 2010

### DIFF
--- a/email.html
+++ b/email.html
@@ -88,6 +88,14 @@ Email on Acid - http://www.emailonacid.com/blog/details/C18/doctype_-_the_black_
 		**/
 		table td {border-collapse: collapse;}
 
+    /** Remove spacing around Outlook 07, 10 tables
+
+    More info : http://www.campaignmonitor.com/blog/post/3694/removing-spacing-from-around-tables-in-outlook-2007-and-2010/
+
+    Bring inline: Yes
+    **/
+    table { border-collapse:collapse; mso-table-lspace:0pt; mso-table-rspace:0pt; }
+
 		/* Styling your links has become much simpler with the new Yahoo.  In fact, it falls in line with the main credo of styling in email, bring your styles inline.  Your link colors will be uniform across clients when brought inline.
 
 		Bring inline: Yes. */

--- a/email_lite.html
+++ b/email_lite.html
@@ -44,6 +44,10 @@
 		Bring inline: No.*/
 		table td {border-collapse: collapse;}
 
+    /* Remove spacing around Outlook 07, 10 tables
+    Bring inline: Yes */
+    table { border-collapse:collapse; mso-table-lspace:0pt; mso-table-rspace:0pt; }
+
 		/* Styling your links has become much simpler with the new Yahoo.  In fact, it falls in line with the main credo of styling in email and make sure to bring your styles inline.  Your link colors will be uniform across clients when brought inline.
 		Bring inline: Yes. */
 		a {color: orange;}


### PR DESCRIPTION
Source : http://www.campaignmonitor.com/blog/post/3694/removing-spacing-from-around-tables-in-outlook-2007-and-2010/
